### PR TITLE
Map standard guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ Current requestbody and responsebody are only for presentation. A common respons
 | Method| POST |
 | Input | {"firstname": "Foo","surname": "Wang"} |
 | Output| Guidance in Json format |
+#### Get standard guidance according type of illness
+| | Value |
+| ----------- | ----------- |
+| URL| http://localhost:5503/diagnosis/advice |
+| Method| POST |
+| Input | {"type": "Schnittwunde"} |
+| Output| ["guidance01", "guidance02", "guidance03" ...] |
 =======
 # SW-distributed-system
 Repository for the software project „Distributed System“

--- a/database/Diagnosis.sql
+++ b/database/Diagnosis.sql
@@ -71,3 +71,28 @@ CREATE TABLE diagnosis_db.outbox (
 );
 
 ALTER TABLE diagnosis_db.outbox OWNER TO postgres;
+
+CREATE TABLE diagnosis_db.guide (
+    id        integer NOT NULL PRIMARY KEY,
+    type      text    NOT NULL,
+    advice    text[]  NOT NULL
+);
+
+ALTER TABLE diagnosis_db.guide ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+    SEQUENCE NAME diagnosis_db.guide_id
+    START WITH 0
+    INCREMENT BY 1
+    MINVALUE 0
+    NO MAXVALUE
+    CACHE 1
+);
+
+INSERT INTO diagnosis_db.guide (type, advice) 
+VALUES ('Schnittwunde', 
+        '{
+            "Nach ca. 10 Tagen zu Ihrem Hausarzt und Fäden ziehen lassen", 
+            "Körperliche Belastung/ Krafttraining in den ersten 48 Stunden meiden", 
+            "Schwimmen, Sauna erst nach Entfernung der Fäden",
+            "Ggf. Tetanusstatus hausärztlich klären lassen, falls Schutzimpfung in Notaufnahme abgelehnt wurde",
+            "Darauf achten den Verband möglichst keimfrei zu wechseln (siehe Vieoanleitung)"
+        }');

--- a/diagnosis/pom.xml
+++ b/diagnosis/pom.xml
@@ -49,6 +49,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.vladmihalcea</groupId>
+            <artifactId>hibernate-types-52</artifactId>
+            <version>2.9.10</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/diagnosis/src/main/java/swp/charite/diagnosis/controller/GuidanceController.java
+++ b/diagnosis/src/main/java/swp/charite/diagnosis/controller/GuidanceController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import swp.charite.diagnosis.dto.GuidanceFromDoctor;
 import swp.charite.diagnosis.dto.GuidanceToPatient;
+import swp.charite.diagnosis.dto.TypeDto;
 import swp.charite.diagnosis.service.DiagnosisService;
 import swp.charite.diagnosis.service.GuidanceService;
 
@@ -34,6 +35,16 @@ public class GuidanceController {
         Long dia_id = diagnosisService.findByPatient(p_id);
         GuidanceToPatient guidance = guidanceService.query(dia_id);
         return new ResponseEntity<GuidanceToPatient>(guidance, HttpStatus.OK);
+    }
+
+    @PostMapping(value = "/advice")
+    public ResponseEntity<?> getAdvice(@RequestBody TypeDto typeDto){
+        String[] advice = guidanceService.getAdvice(typeDto.getType());
+        if (advice != null) {
+            return new ResponseEntity<String[]>(advice, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
     }
 
 }

--- a/diagnosis/src/main/java/swp/charite/diagnosis/dto/TypeDto.java
+++ b/diagnosis/src/main/java/swp/charite/diagnosis/dto/TypeDto.java
@@ -1,0 +1,10 @@
+package swp.charite.diagnosis.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TypeDto {
+    private String type;
+}

--- a/diagnosis/src/main/java/swp/charite/diagnosis/model/Guide.java
+++ b/diagnosis/src/main/java/swp/charite/diagnosis/model/Guide.java
@@ -1,0 +1,43 @@
+package swp.charite.diagnosis.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+
+import com.vladmihalcea.hibernate.type.array.StringArrayType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "guide", schema = "diagnosis_db")
+@TypeDefs({
+    @TypeDef(name = "string-array",typeClass = StringArrayType.class)
+})
+public class Guide {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "type")
+    private String type;
+
+    @Type(type = "string-array")
+    @Column(name = "advice", columnDefinition = "text[]")
+    private String[] advice;
+}

--- a/diagnosis/src/main/java/swp/charite/diagnosis/repository/GuideRepository.java
+++ b/diagnosis/src/main/java/swp/charite/diagnosis/repository/GuideRepository.java
@@ -1,0 +1,15 @@
+package swp.charite.diagnosis.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import swp.charite.diagnosis.model.Guide;
+
+@Repository
+public interface GuideRepository extends JpaRepository<Guide, Long> {
+    
+    public Guide findByType(String type);
+
+    public Boolean existsByType(String type);
+    
+}

--- a/diagnosis/src/main/java/swp/charite/diagnosis/service/GuidanceService.java
+++ b/diagnosis/src/main/java/swp/charite/diagnosis/service/GuidanceService.java
@@ -12,8 +12,10 @@ import swp.charite.diagnosis.dto.GuidanceFromDoctor;
 import swp.charite.diagnosis.dto.GuidanceToPatient;
 import swp.charite.diagnosis.dto.GuidanceCreateEventDto;
 import swp.charite.diagnosis.model.Guidance;
+import swp.charite.diagnosis.model.Guide;
 import swp.charite.diagnosis.model.OutboxEntity;
 import swp.charite.diagnosis.repository.GuidanceRepository;
+import swp.charite.diagnosis.repository.GuideRepository;
 import swp.charite.diagnosis.repository.OutboxRepository;
 
 @Service
@@ -24,6 +26,9 @@ public class GuidanceService {
 
     @Autowired
     private GuidanceRepository guidanceRepository;
+
+    @Autowired
+    private GuideRepository guideRepository;
 
     @Autowired
     private OutboxRepository outboxRepository;
@@ -51,6 +56,15 @@ public class GuidanceService {
         if (guidanceRepository.existsByDiagnosisId(dia_id)){
             Guidance guidance = guidanceRepository.findByDiagnosisId(dia_id);
             return new GuidanceToPatient(guidance.getGuidance(), guidance.getPriority().toString(), guidance.getDone());
+        } else {
+            return null;
+        }
+    }
+
+    public String[] getAdvice(String type) {
+        if (guideRepository.existsByType(type)) {
+            Guide guide = guideRepository.findByType(type);
+            return guide.getAdvice();
         } else {
             return null;
         }


### PR DESCRIPTION
Created one new table to store all standard guidance connected with different illness. When client chooses one type of illness, backend will send back a list of all standard guidance back. Doctor can decide which of them are needed and add them to the final guidance.