### PR TITLE
[client] client can get standard guidance when choosing one type of illness

### DIFF
--- a/client/lib/pages/doctor/guidance/guidance_window.dart
+++ b/client/lib/pages/doctor/guidance/guidance_window.dart
@@ -38,9 +38,12 @@ class _GuidanceWindowState extends State<GuidanceWindow> {
 
 //var guidance
   String dropdownvalue = '...';
+  List<String> advice = <String>[];
+  TextEditingController _guidance = TextEditingController();
   var items = [
     '...',
     'Kopfschmerzen',
+    'Schnittwunde',
     'Knochenbruch',
     'Entfernung von einer Naht',
     'Krebs, Frühstadium',
@@ -94,6 +97,20 @@ class _GuidanceWindowState extends State<GuidanceWindow> {
         },
         body: reqBody);
     return res.body;
+  }
+
+  Future getAdvice() async {
+    var url = Uri.parse("http://ed-gateway:8080/diagnosis/advice");
+    var req_body = json.encode({'type': dropdownvalue});
+    var res = await http.post(url,
+        headers: {'Content-Type': 'application/json'}, body: req_body);
+
+    _guidance.clear();
+
+    for (var value in JsonDecoder().convert(res.body)) {
+      advice.add(value);
+      _guidance.text += value;
+    }
   }
 
 //############ func qr Code ##############
@@ -273,6 +290,7 @@ class _GuidanceWindowState extends State<GuidanceWindow> {
                               onChanged: (String? newValue) {
                                 setState(() {
                                   dropdownvalue = newValue!;
+                                  getAdvice();
                                 });
                               },
                             ),
@@ -281,6 +299,16 @@ class _GuidanceWindowState extends State<GuidanceWindow> {
                             decoration: InputDecoration(
                                 hintText:
                                     "PatientID, imported from creat/load patient page"),
+                          ),
+                          SizedBox(
+                            height: 20,
+                          ),
+                          TextField(
+                            controller: _guidance,
+                            decoration: InputDecoration(hintText: "Guidance here"),
+                            keyboardType: TextInputType.multiline,
+                            maxLines: 10,
+                            minLines: 1,
                           ),
                         ])))),
                 margin: const EdgeInsets.all(5),

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -77,14 +77,14 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
@@ -150,7 +150,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -164,7 +164,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   path_parsing:
     dependency: transitive
     description:
@@ -185,14 +185,14 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.16"
+    version: "2.0.14"
   path_provider_ios:
     dependency: transitive
     description:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.9"
   path_provider_linux:
     dependency: transitive
     description:
@@ -220,7 +220,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.0.7"
   pdf:
     dependency: "direct main"
     description:
@@ -234,7 +234,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "4.4.0"
   platform:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -316,7 +316,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -330,14 +330,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.5.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.1"
+    version: "5.3.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=2.16.2 <3.0.0"
+  flutter: ">=2.8.1"

--- a/client/windows/flutter/generated_plugins.cmake
+++ b/client/windows/flutter/generated_plugins.cmake
@@ -5,9 +5,6 @@
 list(APPEND FLUTTER_PLUGIN_LIST
 )
 
-list(APPEND FLUTTER_FFI_PLUGIN_LIST
-)
-
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -16,8 +13,3 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
-
-foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
-  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
-  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
-endforeach(ffi_plugin)


### PR DESCRIPTION
I created a new TextField to show and modify guidance. When choosing illness "Schnittwunde", it will automaticly show all standard guidance and then doctor can modify them as needed case by case. When choosing others the TextField will be empty since we don't have other standard guidance in backend.

Maybe Florian can adjust the size of GuidanceContainer so that it can show all guidance. Now the space is too narrow.